### PR TITLE
devices: fix typo for gs101 devices

### DIFF
--- a/everest.devices
+++ b/everest.devices
@@ -22,5 +22,5 @@ wly
 spartan
 cheetah
 Pong
-Oriole
-Raven
+oriole
+raven


### PR DESCRIPTION
vendor/everest checks if devices are listed on this file, but is also case-sensitive so if device codename is oriole it must be added as oriole with small O.
